### PR TITLE
Sanitize credentials in connection string logs

### DIFF
--- a/beef/redis.go
+++ b/beef/redis.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/b-open-io/overlay/internal/utils"
 	"github.com/bsv-blockchain/go-sdk/chainhash"
 	"github.com/bsv-blockchain/go-sdk/transaction/chaintracker"
 	"github.com/redis/go-redis/v9"
@@ -44,7 +45,7 @@ func NewRedisBeefStorage(connString string, fallback BeefStorage) (*RedisBeefSto
 
 	r.ttl = cacheTTL
 
-	log.Println("Connecting to Redis BeefStorage...", cleanConnString)
+	log.Println("Connecting to Redis BeefStorage...", utils.SanitizeConnectionString(cleanConnString))
 	if opts, err := redis.ParseURL(cleanConnString); err != nil {
 		return nil, err
 	} else {

--- a/beef/redis.go
+++ b/beef/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -45,7 +46,7 @@ func NewRedisBeefStorage(connString string, fallback BeefStorage) (*RedisBeefSto
 
 	r.ttl = cacheTTL
 
-	log.Println("Connecting to Redis BeefStorage...", utils.SanitizeConnectionString(cleanConnString))
+	slog.Debug("Connecting to Redis BeefStorage", "url", utils.SanitizeConnectionString(cleanConnString))
 	if opts, err := redis.ParseURL(cleanConnString); err != nil {
 		return nil, err
 	} else {

--- a/beef/redis.go
+++ b/beef/redis.go
@@ -29,7 +29,7 @@ func NewRedisBeefStorage(connString string, fallback BeefStorage) (*RedisBeefSto
 	// Parse TTL from query parameters if present
 	// Example: redis://localhost:6379?ttl=24h
 	var cacheTTL time.Duration
-	cleanConnString := connString
+	connStringForRedis := connString
 
 	if idx := strings.Index(connString, "?"); idx != -1 {
 		// Extract TTL from query string before parsing URL
@@ -41,13 +41,13 @@ func NewRedisBeefStorage(connString string, fallback BeefStorage) (*RedisBeefSto
 			}
 		}
 		// Redis ParseURL doesn't understand ttl parameter, so remove it
-		cleanConnString = connString[:idx]
+		connStringForRedis = connString[:idx]
 	}
 
 	r.ttl = cacheTTL
 
-	slog.Debug("Connecting to Redis BeefStorage", "url", utils.SanitizeConnectionString(cleanConnString))
-	if opts, err := redis.ParseURL(cleanConnString); err != nil {
+	slog.Debug("Connecting to Redis BeefStorage", "url", utils.SanitizeConnectionString(connStringForRedis))
+	if opts, err := redis.ParseURL(connStringForRedis); err != nil {
 		return nil, err
 	} else {
 		r.db = redis.NewClient(opts)

--- a/internal/utils/sanitize.go
+++ b/internal/utils/sanitize.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"net/url"
+	"strings"
+)
+
+// SanitizeConnectionString removes credentials from connection strings for safe logging
+func SanitizeConnectionString(connStr string) string {
+	if connStr == "" {
+		return ""
+	}
+
+	// Handle redis:// URLs
+	if strings.HasPrefix(connStr, "redis://") || strings.HasPrefix(connStr, "rediss://") {
+		parsedURL, err := url.Parse(connStr)
+		if err != nil {
+			// If parsing fails, just redact the whole thing after the scheme
+			parts := strings.SplitN(connStr, "://", 2)
+			if len(parts) == 2 {
+				return parts[0] + "://*****"
+			}
+			return "*****"
+		}
+
+		// Redact password
+		if parsedURL.User != nil {
+			parsedURL.User = url.UserPassword(parsedURL.User.Username(), "*****")
+		}
+
+		return parsedURL.String()
+	}
+
+	// Handle mongodb:// and mongodb+srv:// URLs
+	if strings.HasPrefix(connStr, "mongodb://") || strings.HasPrefix(connStr, "mongodb+srv://") {
+		parsedURL, err := url.Parse(connStr)
+		if err != nil {
+			parts := strings.SplitN(connStr, "://", 2)
+			if len(parts) == 2 {
+				return parts[0] + "://*****"
+			}
+			return "*****"
+		}
+
+		// Redact password
+		if parsedURL.User != nil {
+			parsedURL.User = url.UserPassword(parsedURL.User.Username(), "*****")
+		}
+
+		return parsedURL.String()
+	}
+
+	// For unknown formats, try to redact anything that looks like a password
+	// Pattern: anything between : and @ in a URL-like string
+	if strings.Contains(connStr, "@") {
+		parts := strings.Split(connStr, "@")
+		if len(parts) >= 2 {
+			userPart := parts[0]
+			if colonIdx := strings.LastIndex(userPart, ":"); colonIdx != -1 {
+				return userPart[:colonIdx+1] + "*****@" + strings.Join(parts[1:], "@")
+			}
+		}
+	}
+
+	return connStr
+}

--- a/queue/redis.go
+++ b/queue/redis.go
@@ -2,7 +2,7 @@ package queue
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"strconv"
 
 	"github.com/b-open-io/overlay/internal/utils"
@@ -22,7 +22,7 @@ func (r *RedisQueueStorage) Close() error {
 }
 
 func NewRedisQueueStorage(connString string) (*RedisQueueStorage, error) {
-	log.Println("Connecting to Redis Queue Storage...", utils.SanitizeConnectionString(connString))
+	slog.Debug("Connecting to Redis Queue Storage", "url", utils.SanitizeConnectionString(connString))
 	opts, err := redis.ParseURL(connString)
 	if err != nil {
 		return nil, err

--- a/queue/redis.go
+++ b/queue/redis.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/b-open-io/overlay/internal/utils"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -21,7 +22,7 @@ func (r *RedisQueueStorage) Close() error {
 }
 
 func NewRedisQueueStorage(connString string) (*RedisQueueStorage, error) {
-	log.Println("Connecting to Redis Queue Storage...", connString)
+	log.Println("Connecting to Redis Queue Storage...", utils.SanitizeConnectionString(connString))
 	opts, err := redis.ParseURL(connString)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem
Redis connection strings with credentials were being logged in plaintext at all times, exposing sensitive information in application logs.

Example of insecure log output:
```
Connecting to Redis BeefStorage... redis://default:PASSWORD@redis.railway.internal:6379
```

## Solution
- Created `internal/utils/sanitize.go` with `SanitizeConnectionString()` utility
- Updated `beef/redis.go` to use `slog.Debug` with sanitized connection strings
- Updated `queue/redis.go` to use `slog.Debug` with sanitized connection strings
- Connection strings now only logged at DEBUG level (not in production)

## Result
- **Production**: No connection strings logged at all (unless debug level enabled)
- **Debug mode**: Passwords redacted in logs:
```
level=DEBUG msg="Connecting to Redis BeefStorage" url="redis://default:*****@redis.railway.internal:6379"
```

## Security Impact
- Prevents credential leakage in production logs
- Uses structured logging (`slog`) with proper log levels
- Supports redis://, rediss://, mongodb://, and mongodb+srv:// URLs
- Maintains full functionality while improving security posture